### PR TITLE
Handle expiring tiles through all zoom levels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,6 +488,7 @@ build-test-pbf: init-dirs
 expire-tiles:
 	@echo "Expiring tiles"
 	@find data/expire_tiles/???????? -name *.tiles | xargs cat > data/expire_tiles/expire_tiles.tiles
+	./script/expire_tiles_zoom
 	@sed --in-place --expression=s/$$/\.pbf/ data/expire_tiles/expire_tiles.tiles
 	$(DOCKER_COMPOSE) exec postserve-cache wget --input-file=/data/expire_tiles/expire_tiles.tiles --base=http://localhost/purge/tiles/ --quiet --output-file=/dev/null || true
 	@rm -rf data/expire_tiles/

--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,7 @@ build-test-pbf: init-dirs
 expire-tiles:
 	@echo "Expiring tiles"
 	@find data/expire_tiles/???????? -name *.tiles | xargs cat > data/expire_tiles/expire_tiles.tiles
-	./script/expire_tiles_zoom
+	@./script/expire_tiles_zoom
 	@sed --in-place --expression=s/$$/\.pbf/ data/expire_tiles/expire_tiles.tiles
 	$(DOCKER_COMPOSE) exec postserve-cache wget --input-file=/data/expire_tiles/expire_tiles.tiles --base=http://localhost/purge/tiles/ --quiet --output-file=/dev/null || true
 	@rm -rf data/expire_tiles/

--- a/script/expire_tiles_zoom
+++ b/script/expire_tiles_zoom
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+cat data/expire_tiles/expire_tiles.tiles > data/expire_tiles/expire_tiles_zoom.tiles
+
+while read line; do
+	zoom=`echo $line | cut -d '/' -f 1`
+
+	# Exit if we have processed all zooms levels
+	if [ "$zoom" -eq "0" ]; then
+		break;
+	fi
+
+	x=`echo $line | cut -d '/' -f 2`
+	y=`echo $line | cut -d '/' -f 3`
+
+	# Write upper tile for this tile
+	echo "$((zoom-1))/$((x/2))/$((y/2))" >> data/expire_tiles/expire_tiles_zoom.tiles
+done < data/expire_tiles/expire_tiles_zoom.tiles
+
+# Sort and deduplicate tiles
+cat data/expire_tiles/expire_tiles_zoom.tiles | sort | uniq > data/expire_tiles/expire_tiles.tiles
+rm -f data/expire_tiles/expire_tiles_zoom.tiles


### PR DESCRIPTION
Sur la base des tuiles expirées au zoom 17, détermine les tuiles à expirer aux zooms inférieurs. J'ai fait ça via un script Bash qui divise par 2 chaque identifiant de tuiles.