### PR TITLE
On-premise guide, config update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ export TPORT
 # Allow a custom docker-compose project name
 ifeq ($(strip $(DC_PROJECT)),)
   DC_PROJECT := $(notdir $(shell pwd))
-  DOCKER_COMPOSE := docker-compose
+  DOCKER_COMPOSE := docker compose
 else
-  DOCKER_COMPOSE := docker-compose --project-name $(DC_PROJECT)
+  DOCKER_COMPOSE := docker compose --project-name $(DC_PROJECT)
 endif
 
 # Make some operations quieter (e.g. inside the test script)
@@ -520,7 +520,7 @@ ifneq ($(strip $(NO_REFRESH)),)
 else
 	@echo ""
 	@echo "Refreshing docker images... Use NO_REFRESH=1 to skip."
-	docker-compose pull --ignore-pull-failures $(QUIET_FLAG) openmaptiles-tools postgres
+	docker compose pull --ignore-pull-failures $(QUIET_FLAG) openmaptiles-tools postgres
 endif
 
 .PHONY: remove-docker-images
@@ -544,7 +544,7 @@ test-perf-null: init-dirs
 
 .PHONY: build-test-pbf
 build-test-pbf: init-dirs
-	docker-compose run $(DC_OPTS) openmaptiles-tools /tileset/.github/workflows/build-test-data.sh
+	docker compose run $(DC_OPTS) openmaptiles-tools /tileset/.github/workflows/build-test-data.sh
 
 .PHONY: expire-tiles
 expire-tiles:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ To serve the tiles on another host than `localhost:8090`, for instance `indooreq
 
     postserve --serve=https://indoorequal.org indoorequal.yaml
 
+
+## Launch your own map of premises
+1. `git clone https://github.com/indoorequal/indoorequal`
+2. Prepare .OSM (or other) map with indoor tags
+3. Convert map to .osm.pbf with `osmconvert64 plan.osm --out-pbf > plan.osm.pbf`
+4. Put them to ./data 
+5. Tune params in .env (like `BBOX`, `DIFF_MODE=false` and `AREA=plan`)
+6. Import to map BD with `make import-osm && make import-sql`
+7. Add `OMT_HOST=https://example.com` and `PPORT=443` for external access to tiles
+8. Serve with `docker compose up -d postgres postserve postserve-cache`
+
+
 ## License
 
 All code in this repository is under the [BSD license](./LICENSE.md) and the cartography decisions encoded in the schema and SQL are licensed under [CC-BY](./LICENSE.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ services:
     environment:
       TILESET_FILE: ${TILESET_FILE}
       STATE_FILE: /tileset/data/last.state.txt
+    depends_on:
+      - postgres
     networks:
       - postgres
       - web
@@ -69,3 +71,5 @@ services:
       - ./postserve-cache.conf:/etc/nginx/conf.d/default.conf:ro
     networks:
       - web
+    depends_on:
+      - postserve


### PR DESCRIPTION
Made some changes
a01f714 - Not too long ago they introduced a docker compose plugin into the standard docker delivery, which does not require an additional binary to be installed `docker-compose`
ec26141 - Dependence of services on each other allows services to be launched more correctly
